### PR TITLE
Fix syntax error on yarn start

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ function logRoutes(port) {
   console.log(
     'Read more: https://www.twilio.com/docs/frontline/nodejs-demo-quickstart#configure-the-twilio-frontline-integration-service'
   );
+}  
 
 app.listen(config.port, () => {
   console.info(`Application started at http://localhost:${config.port}`);


### PR DESCRIPTION
Fixes "SyntaxError: Unexpected end of input" error when launching the demo

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.
